### PR TITLE
feat: add new fields in the cripto model

### DIFF
--- a/dbt/jaffle_shop/macros/map_values_from_seed.sql
+++ b/dbt/jaffle_shop/macros/map_values_from_seed.sql
@@ -1,0 +1,29 @@
+{%- macro map_values_from_seed(column_to_map, seed_name, value_not_in_seed_then_null=False) -%}
+
+    {%- set seed_query -%}
+        select *
+        from {{ ref(seed_name) }}
+    {%- endset -%}
+
+    {%- set values_to_map_from_seed = run_query(seed_query) -%}
+
+    {% if execute %}
+
+        case
+        {% for value_from in values_to_map_from_seed.columns[0].values() -%}
+            {%- set value_to = values_to_map_from_seed.columns[1].values()[loop.index0] -%}
+            {%- if value_to not in ['null', 'none', None] -%}
+                when lower({{ column_to_map }}) = '{{ value_from }}' then '{{ value_to }}'
+            {% else %}
+                when lower({{ column_to_map }}) = '{{ value_from }}' then null
+            {% endif -%}
+        {%- endfor %}
+
+            {%- if not value_not_in_seed_then_null -%}
+                else {{ column_to_map }}
+            {% endif -%}
+        end
+
+    {% endif %}
+
+{% endmacro %}

--- a/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
+++ b/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
@@ -10,6 +10,8 @@ stage as (
     select
 
         exchange_name,
+        'Cripto Exchange Rate (USDT / ARS)'  as indicator_description,
+        'Criptoya - Cripto' as source_reference,
         ask_price,
         total_ask_price,
         bid_price,

--- a/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
+++ b/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
@@ -10,7 +10,7 @@ stage as (
     select
 
         {{ map_values_from_seed('exchange_name','exchange_names_mapping') }} as exchange_name,
-        'Cripto Exchange Rate (USDT / ARS)'  as indicator_description,
+        'Cripto Exchange Rate (USDT / ARS)' as indicator_description,
         'Criptoya - Cripto' as source_reference,
         ask_price,
         total_ask_price,

--- a/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
+++ b/dbt/jaffle_shop/models/staging/stg_exchange_rates_cripto_usdt_ars.sql
@@ -9,7 +9,7 @@ stage as (
 
     select
 
-        exchange_name,
+        {{ map_values_from_seed('exchange_name','exchange_names_mapping') }} as exchange_name,
         'Cripto Exchange Rate (USDT / ARS)'  as indicator_description,
         'Criptoya - Cripto' as source_reference,
         ask_price,

--- a/dbt/jaffle_shop/seeds/exchange_names_mapping.csv
+++ b/dbt/jaffle_shop/seeds/exchange_names_mapping.csv
@@ -1,0 +1,37 @@
+exchange_name_original,exchange_name_new
+argenbtc,ArgenBTC
+buenbit,Buenbit
+ripio,Ripio
+ripioexchange,Ripio Exchange
+satoshitango,Satoshitango
+cryptomkt,Cryptomkt
+decrypto,Decrypto
+latamex,Latamex
+letsbit,Letsbit
+binancep2p,Binance P2P
+fiwind,Fiwind
+lemoncash,Lemon Cash
+okexp2p,Okex P2P
+bitmonedero,Bit Monedero
+paxfulp2p,Paxful P2P
+belo,Belo
+huobip2p,Huobi P2P
+tiendacrypto,Tiendacrypto
+bybitp2p,Bybit P2P
+kucoinp2p,Kucoin P2P
+saldo,Saldo
+kriptonmarket,Kripton Market
+trubitp2p,Trubit P2P
+calypso,Calypso
+bitgetp2p,Bitget P2P
+pluscrypto,Pluscrypto
+bybit,Bybit
+eluter,Eluter
+binance,Binance
+paydecep2p,Paydece P2P
+eldoradop2p,El Dorado P2P
+trubit,Trubit
+bingxp2p,Bingx P2P
+bitsoalpha,Bitso Alpha
+lemoncashp2p,Lemon Cash P2P
+cocoscrypto,Cocos Crypto

--- a/dbt/jaffle_shop/seeds/seeds.yml
+++ b/dbt/jaffle_shop/seeds/seeds.yml
@@ -2,9 +2,7 @@ version: 2
 
 seeds:
   - name: exchange_names_mapping
-    config:
-      y42:
-        apiVersion: v1
+    description: Mapping exchange names from Criptoya.
     columns:
       - name: EXCHANGE_NAME_ORIGINAL
         data_type: TEXT
@@ -18,6 +16,3 @@ seeds:
           - not_null
           - unique
         description: Name of the Exchange renamed from the Cryptoya API.
-    meta:
-      asset_status: verified
-    description: Mapping exchange names from Criptoya.

--- a/dbt/jaffle_shop/seeds/seeds.yml
+++ b/dbt/jaffle_shop/seeds/seeds.yml
@@ -1,0 +1,23 @@
+version: 2
+
+seeds:
+  - name: exchange_names_mapping
+    config:
+      y42:
+        apiVersion: v1
+    columns:
+      - name: EXCHANGE_NAME_ORIGINAL
+        data_type: TEXT
+        tests:
+          - unique
+          - not_null
+        description: Original Exchange Name from the Criptoya API.
+      - name: EXCHANGE_NAME_NEW
+        data_type: TEXT
+        tests:
+          - not_null
+          - unique
+        description: Name of the Exchange renamed from the Cryptoya API.
+    meta:
+      asset_status: verified
+    description: Mapping exchange names from Criptoya.


### PR DESCRIPTION
- add new fields in the `stg_exchange_rates_cripto_usdt_ars` model.
- create `map_values_from_seed `macro
- create seed to mapping exchange names.